### PR TITLE
Switch to tarot deck

### DIFF
--- a/deck/models.py
+++ b/deck/models.py
@@ -20,14 +20,58 @@ class User(AbstractUser):
         return self.email
 
 
-CARDS = ['AS', '2S', '3S', '4S', '5S', '6S', '7S', '8S', '9S', '0S', 'JS', 'QS', 'KS',
-         'AD', '2D', '3D', '4D', '5D', '6D', '7D', '8D', '9D', '0D', 'JD', 'QD', 'KD',
-         'AC', '2C', '3C', '4C', '5C', '6C', '7C', '8C', '9C', '0C', 'JC', 'QC', 'KC',
-         'AH', '2H', '3H', '4H', '5H', '6H', '7H', '8H', '9H', '0H', 'JH', 'QH', 'KH']
-JOKERS = ['X1', 'X2']
+MINOR_VALUES = ['A', '2', '3', '4', '5', '6', '7', '8', '9', '0', 'P', 'N', 'Q', 'K']
+MAJOR_ARCANA_VALUES = {
+    '0': 'THE FOOL',
+    '1': 'THE MAGICIAN',
+    '2': 'THE HIGH PRIESTESS',
+    '3': 'THE EMPRESS',
+    '4': 'THE EMPEROR',
+    '5': 'THE HIEROPHANT',
+    '6': 'THE LOVERS',
+    '7': 'THE CHARIOT',
+    '8': 'STRENGTH',
+    '9': 'THE HERMIT',
+    'A': 'WHEEL OF FORTUNE',
+    'B': 'JUSTICE',
+    'C': 'THE HANGED MAN',
+    'D': 'DEATH',
+    'E': 'TEMPERANCE',
+    'F': 'THE DEVIL',
+    'G': 'THE TOWER',
+    'H': 'THE STAR',
+    'I': 'THE MOON',
+    'J': 'THE SUN',
+    'K': 'JUDGEMENT',
+    'L': 'THE WORLD'
+}
 
-SUITS = {'S': 'SPADES', 'D': 'DIAMONDS', 'H': 'HEARTS', 'C': 'CLUBS', '1': 'BLACK', '2': 'RED'}
-VALUES = {'A': 'ACE', 'J': 'JACK', 'Q': 'QUEEN', 'K': 'KING', '0': '10', 'X': 'JOKER'}
+CARDS = [v + s for s in ['W', 'C', 'S', 'P'] for v in MINOR_VALUES] + [k + 'M' for k in MAJOR_ARCANA_VALUES.keys()]
+JOKERS = []
+
+SUITS = {
+    'W': 'WANDS',
+    'C': 'CUPS',
+    'S': 'SWORDS',
+    'P': 'PENTACLES',
+    'M': 'MAJOR'
+}
+VALUES = {
+    'A': 'ACE',
+    '2': '2',
+    '3': '3',
+    '4': '4',
+    '5': '5',
+    '6': '6',
+    '7': '7',
+    '8': '8',
+    '9': '9',
+    '0': '10',
+    'P': 'PAGE',
+    'N': 'KNIGHT',
+    'Q': 'QUEEN',
+    'K': 'KING'
+}
 
 class Deck(models.Model):
     key = models.CharField(default=random_string, max_length=15, db_index=True)
@@ -78,11 +122,10 @@ def card_to_dict(card):
         }
     }
 
-    if code == 'AD':
-        card_dict['image'] = 'https://deckofcardsapi.com/static/img/aceDiamonds.png'
-        card_dict['images']['png'] = 'https://deckofcardsapi.com/static/img/aceDiamonds.png'
-        card_dict['images']['svg'] = 'https://deckofcardsapi.com/static/img/aceDiamonds.svg'
-
-    card_dict['value'] = VALUES.get(value) or value
-    card_dict['suit'] = SUITS.get(suit) or suit
+    if suit == 'M':
+        card_dict['value'] = MAJOR_ARCANA_VALUES.get(value, value)
+        card_dict['suit'] = SUITS.get(suit, suit)
+    else:
+        card_dict['value'] = VALUES.get(value) or value
+        card_dict['suit'] = SUITS.get(suit) or suit
     return card_dict

--- a/deck/tests.py
+++ b/deck/tests.py
@@ -26,10 +26,10 @@ class DeckTest(TestCase):
         resp = json.loads(response.content.decode('utf-8'))
         self.assertEqual(resp['success'], True)
         ace = resp['cards'][0]
-        self.assertEqual(ace['suit'], 'SPADES')
+        self.assertEqual(ace['suit'], 'WANDS')
         self.assertEqual(ace['value'], 'ACE')
-        self.assertEqual(ace['code'], 'AS')
-        self.assertEqual(resp['remaining'], 51)
+        self.assertEqual(ace['code'], 'AW')
+        self.assertEqual(resp['remaining'], 77)
 
         request = self.request_factory.get("/", {})
         response = shuffle(request, deck_id)
@@ -37,14 +37,14 @@ class DeckTest(TestCase):
         resp = json.loads(response.content.decode('utf-8'))
         self.assertEqual(resp['success'], True)
         self.assertEqual(resp['shuffled'], True)
-        self.assertEqual(resp['remaining'], 52)
+        self.assertEqual(resp['remaining'], 78)
 
         request = self.request_factory.get("/", {"count": 10})
         response = draw(request, deck_id)
         self.assertEqual(response.status_code, 200)
         resp = json.loads(response.content.decode('utf-8'))
         self.assertEqual(resp['success'], True)
-        self.assertEqual(resp['remaining'], 42)
+        self.assertEqual(resp['remaining'], 68)
         self.assertEqual(len(resp['cards']), 10)
         cards = resp['cards']
 
@@ -56,7 +56,7 @@ class DeckTest(TestCase):
         self.assertEqual(response.status_code, 200)
         resp = json.loads(response.content.decode('utf-8'))
         self.assertEqual(resp['success'], True)
-        self.assertEqual(resp['remaining'], 42)
+        self.assertEqual(resp['remaining'], 68)
         piles = resp['piles']
         self.assertEqual(piles['chase']['remaining'], 2)
         
@@ -83,7 +83,7 @@ class DeckTest(TestCase):
 
     def test_partial_deck(self):
         # test to make sure a new partial deck is returned when requested
-        request = self.request_factory.get("/", {'cards': 'AC,AD,AH,AS'})
+        request = self.request_factory.get("/", {'cards': 'AW,AC,AS,AP'})
         response = shuffle(request)
         self.assertEqual(response.status_code, 200)
         resp = json.loads(response.content.decode('utf-8'))
@@ -100,13 +100,13 @@ class DeckTest(TestCase):
         self.assertEqual(resp['success'], True)
         one, two, three, four = False, False, False, False
         for card in resp['cards']:
-            if card['code'] == 'AS':
+            if card['code'] == 'AW':
                 one = True
-            elif card['code'] == 'AD':
-                two = True
-            elif card['code'] == 'AH':
-                three = True
             elif card['code'] == 'AC':
+                two = True
+            elif card['code'] == 'AS':
+                three = True
+            elif card['code'] == 'AP':
                 four = True
         self.assertEqual(resp['remaining'], 0)
         self.assertEqual(one, True)
@@ -115,7 +115,7 @@ class DeckTest(TestCase):
         self.assertEqual(four, True)
 
         # verify that reshuffling a partial deck returns a partial deck
-        request = self.request_factory.get("/", {'cards': 'KC,KD,KH,KS'})
+        request = self.request_factory.get("/", {'cards': 'KW,KC,KS,KP'})
         response = shuffle(request)
         resp = json.loads(response.content.decode('utf-8'))
         deck_id = resp['deck_id']
@@ -130,4 +130,4 @@ class DeckTest(TestCase):
         self.assertEqual(response.status_code, 200)
         resp = json.loads(response.content.decode('utf-8'))
         self.assertEqual(resp['success'], True)
-        self.assertEqual(resp['remaining'], 47)
+        self.assertEqual(resp['remaining'], 73)


### PR DESCRIPTION
## Summary
- redefine card constants for tarot (78 cards)
- map suits and values for tarot cards
- handle major arcana in `card_to_dict`
- update tests for tarot counts and codes

## Testing
- `python manage.py test -v 2`

------
https://chatgpt.com/codex/tasks/task_e_687e25825570833081bf87ba9d8b908b